### PR TITLE
Revert siphash result swapping

### DIFF
--- a/src/cpp_driver.cpp
+++ b/src/cpp_driver.cpp
@@ -201,11 +201,6 @@ NP_INLINE static nano_pow::uint128_t hash (std::array<uint64_t, 2> nonce_a, uint
 	auto error (siphash (reinterpret_cast<uint8_t const *> (&item_a), sizeof (item_a), reinterpret_cast<uint8_t const *> (nonce_a.data ()), reinterpret_cast<uint8_t *> (&result), sizeof (result)));
 	(void)error;
 	assert (!error);
-	/* Siphash writes to result in memory order.
-	   This means the LSB in written before the MSB
-	   We swap the upper half with the lower half so
-	   the lower half contains the last-written random data. */
-	result = (result >> 64) | (result << 64);
 	return result;
 }
 

--- a/src/opencl_program.cl
+++ b/src/opencl_program.cl
@@ -224,9 +224,6 @@ static uint128_t hash (nonce_t const nonce_a, ulong const item_a)
 {
 	uint128_t result;
 	int code = siphash ((uchar *)&item_a, sizeof (item_a), (uchar *)nonce_a.values, (uchar *)&result, sizeof (result));
-	ulong temp = result.low;
-	result.low = result.high;
-	result.high = temp;
 	return result;
 }
 


### PR DESCRIPTION
This reverts commit 3a86d99544a476642b40257ac29cb7ad94819cb1.

Performance decreased both for generation and validation, not sure why I didn't notice at the time.