### PR TITLE
Allow cancelling ongoing work

### DIFF
--- a/include/nano_pow/cpp_driver.hpp
+++ b/include/nano_pow/cpp_driver.hpp
@@ -91,4 +91,4 @@ public:
 	std::array<uint64_t, 2> nonce{ { 0, 0 } };
 	std::array<uint64_t, 2> result_get ();
 };
-}
+} // namespace nano_pow

--- a/include/nano_pow/driver.hpp
+++ b/include/nano_pow/driver.hpp
@@ -3,6 +3,7 @@
 #include <nano_pow/uint128.hpp>
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 
@@ -18,6 +19,7 @@ class driver
 {
 protected:
 	bool verbose{ false };
+	std::atomic<bool> cancel{ false };
 
 public:
 	virtual ~driver () = default;
@@ -44,6 +46,10 @@ public:
 	virtual std::array<uint64_t, 2> search () = 0;
 	virtual std::array<uint64_t, 2> solve (std::array<uint64_t, 2> nonce) = 0;
 	virtual driver_type type () const = 0;
+	void cancel_current ()
+	{
+		cancel = true;
+	}
 	void verbose_set (bool const v)
 	{
 		verbose = v;

--- a/include/nano_pow/opencl_driver.hpp
+++ b/include/nano_pow/opencl_driver.hpp
@@ -94,6 +94,7 @@ public:
 class opencl_driver : public driver
 {
 public:
+	~opencl_driver ();
 	opencl_driver (unsigned short platform_id = 0, unsigned short device_id = 0, bool initialize = true);
 	void initialize (unsigned short platform_id, unsigned short device_id);
 	void difficulty_set (nano_pow::uint128_t difficulty_a) override;

--- a/include/nano_pow/tuning.hpp
+++ b/include/nano_pow/tuning.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <nano_pow/driver.hpp>
 #include <nano_pow/cpp_driver.hpp>
+#include <nano_pow/driver.hpp>
 #include <nano_pow/opencl_driver.hpp>
 
 namespace nano_pow

--- a/include/nano_pow/uint128.hpp
+++ b/include/nano_pow/uint128.hpp
@@ -378,8 +378,8 @@ using uint128_t = integers128::uint128;
 
 namespace nano_pow
 {
-	nano_pow::uint128_t difficulty_64_to_128 (uint64_t difficulty_a);
-	uint64_t difficulty_128_to_64 (nano_pow::uint128_t difficulty_a);
+nano_pow::uint128_t difficulty_64_to_128 (uint64_t difficulty_a);
+uint64_t difficulty_128_to_64 (nano_pow::uint128_t difficulty_a);
 }
 
 #endif

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -2,12 +2,16 @@
 
 std::array<uint64_t, 2> nano_pow::driver::solve (std::array<uint64_t, 2> nonce)
 {
+	cancel = false;
 	(void)nonce;
 	std::array<uint64_t, 2> result_l = { 0, 0 };
-	while (result_l[1] == 0)
+	while (!cancel && result_l[1] == 0)
 	{
 		fill ();
-		result_l = search ();
+		if (!cancel)
+		{
+			result_l = search ();
+		}
 	}
 	return result_l;
 }

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -18,7 +18,7 @@ TEST (nano_pow, difficulty_128)
 
 TEST (cpp_driver, solve)
 {
-	std::array<uint64_t, 2> nonce { 0, 0 };
+	std::array<uint64_t, 2> nonce{ 0, 0 };
 	nano_pow::cpp_driver driver;
 	ASSERT_FALSE (driver.memory_set (1ULL << 16));
 	driver.difficulty_set (nano_pow::bit_difficulty (32));
@@ -36,7 +36,7 @@ TEST (cpp_driver, solve)
 TEST (opencl_driver, solve)
 {
 	bool opencl_available{ true };
-	std::array<uint64_t, 2> nonce { 0, 0 };
+	std::array<uint64_t, 2> nonce{ 0, 0 };
 	nano_pow::opencl_driver driver (0, 0, false);
 	try
 	{


### PR DESCRIPTION
Along with clang-formatting some things.

Closes #30 . `cancel` is an atomic bool, reset to false on `solve ()`